### PR TITLE
check to make sure we can call object.keys before we do to avoid errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var RegClient = require('silent-npm-registry-client');
 var os = require('os');
 var semver = require('semver');
+var keys = require('amp-keys');
 var async = require('async');
 
 var ASNYC_PARALLELISM = 20;
@@ -22,9 +23,7 @@ function getPackageJson (module, cb) {
             return cb(err);
         }
 
-        var versions = pkg.versions && Object.keys(pkg.versions) || [];
-
-        version = semver.maxSatisfying(versions, module.version) || pkg['dist-tags'].latest;
+        version = semver.maxSatisfying(keys(pkg.versions), module.version) || pkg['dist-tags'].latest;
         doc = pkg.versions[version];
 
         if (!doc) {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/liftsecurity/requiresafe-npm.git"
   },
   "dependencies": {
+    "amp-keys": "^1.0.1",
     "async": "^0.9.0",
     "semver": "^4.2.0",
     "silent-npm-registry-client": "0.0.1"


### PR DESCRIPTION
The requiresafe CLI triggers 500 errors from server when ran on api.requiresafe.com repo. Not entirely sure why, but I know the offending code as descbribed by this pastebin: http://paste.andyet.net/nutudedaso.pas

I fixed this, tests still pass. But would love a double check from someone else as i'm not entirely clear headed about this at the moment.
