### PR TITLE
update to latest silent-npm-registry-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "^lift security",
   "dependencies": {
     "semver": "^5.0.3",
-    "silent-npm-registry-client": "1.0.0"
+    "silent-npm-registry-client": "2.0.0"
   },
   "devDependencies": {
     "eslint": "^1.8.0",


### PR DESCRIPTION
Long story, but `silent-npm-registry-client@1.0.0`  depends on `npm-registry-client@6`, which has a [poorly declared dependency on `npmlog`](https://github.com/npm/npm-registry-client/blob/v6.3.3/package.json#L34), which causes problems when using shrinkwrap on projects that depend on `nsp`.

This change updates to the latest version of the silent client, which in turn uses the latest version of `npm-registry-client` where this optional dep is fixed. Since this is a major version change, it should be released as a major here as well.

Thanks!